### PR TITLE
Solved test project dependencies and added parameterless constructor

### DIFF
--- a/src/HttpMediatR/HttpHandler.cs
+++ b/src/HttpMediatR/HttpHandler.cs
@@ -1,6 +1,7 @@
 ﻿using MediatR;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using System;
 using System.Net;
 using System.Threading;
@@ -16,6 +17,11 @@ namespace HttpMediatR
         where TRequest : class, IHttpRequest
     {
         private readonly ILogger _logger;
+
+        protected HttpHandler()
+        {
+            _logger = NullLogger.Instance;
+        }
 
         protected HttpHandler(ILogger logger)
         {

--- a/tests/HttpMediatR.Tests/HttpMediatR.Tests.csproj
+++ b/tests/HttpMediatR.Tests/HttpMediatR.Tests.csproj
@@ -7,8 +7,8 @@
 
   <ItemGroup>
     <PackageReference Include="MediatR" Version="5.0.1" />
-    <PackageReference Include="Microsoft.AspNetCore.App" Version="2.1.0" />
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="2.1.0" />
+    <PackageReference Include="Microsoft.AspNetCore.App" Version="2.1.1" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="2.1.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.2" />
     <PackageReference Include="Moq" Version="4.8.3" />
     <PackageReference Include="Shouldly" Version="3.0.0" />


### PR DESCRIPTION
The test project had dependencies on .NET core 2.1.0 while the sample was already pointing to 2.1.1. Updated references on the test project so this builds again. 

Also added parameterless constructor so that ILogger is not obligated as dicsussed in issue #1 